### PR TITLE
DC-353: early termination

### DIFF
--- a/app/uk/gov/hmrc/ups/config/Jobs.scala
+++ b/app/uk/gov/hmrc/ups/config/Jobs.scala
@@ -71,13 +71,13 @@ object Jobs {
 
   object UpdatedPrintSuppressionJob extends ExclusiveScheduledJob with DurationFromConfig {
 
-    def executeInMutex(implicit ec: ExecutionContext): Future[UpdatedPrintSuppressionJob.Result] = {
-      PreferencesProcessor.run(HeaderCarrier()).map { totals =>
-        Result(
-          s"UpdatedPrintSuppressions: ${totals.processed} items processed with ${totals.failed} failures"
-        )
-      }
-    }
+    def executeInMutex(implicit ec: ExecutionContext): Future[UpdatedPrintSuppressionJob.Result] =
+      PreferencesProcessor.run(HeaderCarrier()).
+        map { totals =>
+          Result(
+            s"UpdatedPrintSuppressions: ${totals.processed} items processed with ${totals.failed} failures"
+          )
+        }
 
     override val name: String = "updatedPrintSuppressions"
   }

--- a/app/uk/gov/hmrc/ups/connectors/PreferencesConnector.scala
+++ b/app/uk/gov/hmrc/ups/connectors/PreferencesConnector.scala
@@ -27,6 +27,8 @@ import uk.gov.hmrc.ups.config.WSHttp
 import uk.gov.hmrc.ups.model.{Filters, PulledItem, WorkItemRequest}
 import uk.gov.hmrc.workitem.ProcessingStatus
 
+import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
+
 import scala.concurrent.Future
 
 trait PreferencesConnector {
@@ -49,7 +51,10 @@ trait PreferencesConnector {
     http.POST[WorkItemRequest, Option[PulledItem]](
       s"$serviceUrl/preferences/updated-print-suppression/pull-work-item",
       workItemRequest
-    )
+    ).recover { case ex =>
+      Logger.error(s"Call to $serviceUrl/preferences/updated-print-suppression/pull-work-item failed unexpectedly", ex)
+      None
+    }
 
   def changeStatus(callbackUrl: String, status: ProcessingStatus)(implicit hc: HeaderCarrier) =
     http.POST[JsValue, Int](s"$serviceUrl$callbackUrl", Json.obj("status" -> status.name))
@@ -78,6 +83,5 @@ object PreferencesConnector extends PreferencesConnector with ServicesConfig {
   lazy val serviceUrl: String = baseUrl("preferences")
 
   lazy val http = WSHttp
-
 
 }

--- a/it/uk/gov/hmrc/ups/ispec/EntityResolverStub.scala
+++ b/it/uk/gov/hmrc/ups/ispec/EntityResolverStub.scala
@@ -1,6 +1,8 @@
 package uk.gov.hmrc.ups.ispec
 
 import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.http.Fault
+
 import uk.gov.hmrc.domain.TaxIds._
 import uk.gov.hmrc.ups.model.EntityId
 
@@ -28,4 +30,10 @@ trait EntityResolverStub {
         .willReturn(aResponse().withStatus(status))
     )
   }
+
+  def stubExceptionOnGetEntity(entityId: EntityId) =
+    stubFor(
+      get(urlMatching(s"/entity-resolver/${entityId.value}")).
+        willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE))
+    )
 }

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -31,6 +31,11 @@ trait MicroService {
       parallelExecution in Test := false,
       fork in Test := false,
       retrieveManaged := true,
+      scalacOptions ++= List(
+        "-feature",
+        "-Xfatal-warnings",
+        "-Xlint"
+      ),
       evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false)
     )
     .configs(IntegrationTest)

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -33,7 +33,6 @@ trait MicroService {
       retrieveManaged := true,
       scalacOptions ++= List(
         "-feature",
-        "-Xfatal-warnings",
         "-Xlint"
       ),
       evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false)


### PR DESCRIPTION
Terminate early (and gracefully) when failures that are not trapped by the underlying  components occur while communicating with Prefs or Entity Resolver. 
